### PR TITLE
Support Arc Browser

### DIFF
--- a/preferences/arc.json
+++ b/preferences/arc.json
@@ -1,0 +1,3 @@
+{
+  "external_update_url": "https://clients2.google.com/service/update2/crx"
+}

--- a/src/Browser.purs
+++ b/src/Browser.purs
@@ -14,6 +14,7 @@ import Types (Browser(..), PlaywrightBrowser, PlaywrightPage, Script)
 getBrowserName :: Browser -> String
 getBrowserName browser =
   case browser of
+    Arc -> "Arc"
     Chrome -> "Google Chrome"
     Edge -> "Microsoft Edge"
 

--- a/src/Extension.purs
+++ b/src/Extension.purs
@@ -62,6 +62,7 @@ setupPrefsDirectory browser extensionId = do
   -- https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options#using-a-preferences-json-file-macos-and-linux
   let
     extensionDirectory = case browser of
+      Arc -> homeDirectory <> "/Library/Application Support/Arc/User Data/External Extensions"
       Chrome -> homeDirectory <> "/Library/Application Support/Google/Chrome/External Extensions"
       Edge -> homeDirectory <> "/Library/Application Support/Microsoft Edge/External Extensions"
   let preferencesFileSourcePath = appRootPath <> "/preferences/" <> toLower (show browser) <> ".json"

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -34,6 +34,7 @@ browserArg = argument (maybeReader readBrowser) (metavar "BROWSER")
 
 readBrowser :: String -> Maybe Browser
 readBrowser str = case str of
+  "arc" -> Just Arc
   "chrome" -> Just Chrome
   "edge" -> Just Edge
   _ -> Nothing

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -14,7 +14,7 @@ data InstallArgs = InstallArgs { browser :: Browser, extensionId :: String, scri
 
 data ListenArgs = ListenArgs { browser :: Browser }
 
-data Browser = Chrome | Edge
+data Browser = Arc | Chrome | Edge
 
 derive instance genericBrowser :: Generic Browser _
 


### PR DESCRIPTION
This "should" add browser support for "Arc"

 I had some issues bootstrapping and running the project though and I am looking for some guidance.




1. Could not finish`spago build` because of   

```
Cannot import value defaultExecSyncOptions from module Node.ChildProcess
  It either does not exist or the module does not export it.
```

it's not exported in the later versions. I do not know how to pin down a specific version in purescript or if that is even the right approach. In just removed the import and the expressions and it started to build



2. Did not compile 

```
at src/Extension.purs:49:20 - 49:26 (line 49, column 20 - line 49, column 26)

  Could not match type

    Effect

  with type

    Function Int
```

I had to remove  `import Node.Process (exit)` and `exit 1` call 




So my current working space is a bit dirty. 

I was able to install to trigger the installation of extensions though

```
# build project
spago build

# required to find packages
npm install

# run 
# Redux DevTools 
# "https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd"
./index.js install arc lmhkpmbekcpmknklioeibfkpmmfibljd

# run 
# Re-introduce google maps links to search page
# https://chromewebstore.google.com/detail/re-introduce-google-maps/mjkkdbmdflkcjmonelmlokplkgnjcnji 
./index.js install arc mjkkdbmdflkcjmonelmlokplkgnjcnji
```
